### PR TITLE
Throw the appropriate exception when you set the wrong scope

### DIFF
--- a/lib/omniauth_qiita/no_authorization_team_mode_error.rb
+++ b/lib/omniauth_qiita/no_authorization_team_mode_error.rb
@@ -1,0 +1,3 @@
+module OmniAuth::Qiita
+  class NoAuthorizationTeamModeError < StandardError; end
+end


### PR DESCRIPTION
The `invalid_credentials` occurred when the team only user login with the `read_qiita` scope.
So I fixed it.